### PR TITLE
feat: Remove unused threads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ logs_dir: "logs"
 # Input HMM profile with all possible monomers.
 # May remove.
 hmm_profile: "data/AS-HORs-hmmer.hmm"
-# Threads passed to stringdecomposer
-threads: 4
 ```
 
 ### Test

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,5 @@ output_dir: "results"
 benchmarks_dir: "benchmarks"
 logs_dir: "logs"
 hmm_profile: "data/AS-HORs-hmmer.hmm"
-threads: 24
 mem: 8GB
 identity_thr: 90.0

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -3,4 +3,3 @@ output_dir: "test/results"
 benchmarks_dir: "benchmarks"
 logs_dir: "logs"
 hmm_profile: "data/AS-HORs-hmmer.hmm"
-threads: 4

--- a/workflow/rules/stringdecomposer.smk
+++ b/workflow/rules/stringdecomposer.smk
@@ -42,7 +42,7 @@ rule run_stringdecomposer:
         join(BMK_DIR, "run_stringdecomposer_{fname}.txt")
     log:
         join(LOG_DIR, "run_stringdecomposer_{fname}.log"),
-    threads: config["threads"]
+    threads: 1
     conda:
         "../envs/env.yaml"
     shell:


### PR DESCRIPTION
* Removed threads arguments.
    * Stringdecomposer only uses multiple threads when running batches of sequences in the given fasta. Because this workflow runs stringdecomposer per sequence, this parameter is unnecessary.